### PR TITLE
remove examples from sources

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -11,10 +11,6 @@
     {
       "dir": "src",
       "public": "all"
-    },
-    {
-      "dir": "examples",
-      "type": "dev"
     }
   ]
 }


### PR DESCRIPTION
examples are not present yet and it causes `yarn install` to fail