### PR TITLE
Upgrade ReasonReact and bs-platform to latest and update code

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/callstack/reroute#readme",
   "devDependencies": {
-    "bs-platform": "^3.0.0",
-    "reason-react": "^0.4.1"
+    "bs-platform": "^4.0.3",
+    "reason-react": "^0.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/callstack/reroute#readme",
   "devDependencies": {
-    "bs-platform": "^2.1.0",
-    "reason-react": "^0.3.2"
+    "bs-platform": "^3.0.0",
+    "reason-react": "^0.4.1"
   }
 }

--- a/src/ReRoute.re
+++ b/src/ReRoute.re
@@ -15,19 +15,17 @@ module CreateRouter = (Config: RouterConfig) => {
       initialState: () =>
         ReasonReact.Router.dangerouslyGetInitialUrl() |> Config.routeFromUrl,
       reducer: (action, _state) =>
-        switch action {
+        switch (action) {
         | ChangeRoute(route) => ReasonReact.Update(route)
         },
-      subscriptions: self => [
-        Sub(
-          () =>
-            ReasonReact.Router.watchUrl(url =>
-              self.send(ChangeRoute(url |> Config.routeFromUrl))
-            ),
-          ReasonReact.Router.unwatchUrl
-        )
-      ],
-      render: self => children(~currentRoute=self.state)
+      didMount: self => {
+        let watcherID =
+          ReasonReact.Router.watchUrl(url =>
+            self.send(ChangeRoute(url |> Config.routeFromUrl))
+          );
+        self.onUnmount(() => ReasonReact.Router.unwatchUrl(watcherID));
+      },
+      render: self => children(~currentRoute=self.state),
     };
   };
   module Link = {
@@ -44,9 +42,9 @@ module CreateRouter = (Config: RouterConfig) => {
               ReasonReact.Router.push(href);
             }
           )>
-          (ReasonReact.arrayToElement(children))
+          (ReasonReact.array(children))
         </a>;
-      }
+      },
     };
   };
 };

--- a/src/ReRoute.re
+++ b/src/ReRoute.re
@@ -38,7 +38,7 @@ module CreateRouter = (Config: RouterConfig) => {
           href
           onClick=(
             event => {
-              ReactEventRe.Synthetic.preventDefault(event);
+              event->ReactEvent.Synthetic.preventDefault;
               ReasonReact.Router.push(href);
             }
           )>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
-bs-platform@^2.1.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.2.tgz#95ff37719771bbf310e8376fedd1148865c0da19"
+bs-platform@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.0.0.tgz#38f200730db52fdea37819376b6ac3dfb20244c0"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -33,8 +33,10 @@ fbjs@^0.8.16:
     ua-parser-js "^0.7.9"
 
 iconv-lite@~0.4.13:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 is-stream@^1.0.1:
   version "1.1.0"
@@ -83,8 +85,8 @@ prop-types@^15.6.0:
     object-assign "^4.1.1"
 
 "react-dom@>=15.0.0 || >=16.0.0":
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -92,29 +94,33 @@ prop-types@^15.6.0:
     prop-types "^15.6.0"
 
 "react@>=15.0.0 || >=16.0.0":
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-reason-react@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.3.2.tgz#14574b619bd9bf2b6057d681867a5dfa69f2360f"
+reason-react@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.4.1.tgz#f1c8bf0d116be6bf43109912ee4d95e58dd7c64f"
   dependencies:
     react ">=15.0.0 || >=16.0.0"
     react-dom ">=15.0.0 || >=16.0.0"
+
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 ua-parser-js@^0.7.9:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
-bs-platform@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.0.0.tgz#38f200730db52fdea37819376b6ac3dfb20244c0"
+bs-platform@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.3.tgz#4510c1c915cc5b169b5717e5c0ada52d3f99ff98"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -102,9 +102,9 @@ prop-types@^15.6.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-reason-react@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.4.1.tgz#f1c8bf0d116be6bf43109912ee4d95e58dd7c64f"
+reason-react@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.5.3.tgz#10601809742fd991109ec9d69ad4baf2c3f17540"
   dependencies:
     react ">=15.0.0 || >=16.0.0"
     react-dom ">=15.0.0 || >=16.0.0"


### PR DESCRIPTION
bs-platform:  2.2.2 -> 3.0.0
reason-react: 0.3.2 -> 0.4.1

[x] Use new subscriptions api (old is deprecated, see reason-react issue #173)
[x] refmt (single entity switch statement* now has parens + trailing commas enforced)
[x] ReasonReact.arrayToElement -> ReasonReact.array (former is deprecated)

This library is minimal and so the code does not change much fortunately. With these changes, one of my hobby websites still works perfectly, but I'm unsure how it will affect sites in production or if there is hidden complexity that I'm not accounting for. Regarding the writing of the code, I followed the [documentation](https://github.com/reasonml/reason-react/blob/b406a679758bf2d0cd66ce1c03454c779eb9894a/docs/subscriptions-helper.md).

`yarn clean && yarn build` does not output any error on this commit.

On the `master` branch (basically w/o this commit), only one warning occurs with the same command:

```
  Warning number 3
  /projects/reroute/src/ReRoute.re 47:12-37
  
  45 ┆       }
  46 ┆     )>
  47 ┆     (ReasonReact.arrayToElement(children))
  48 ┆   </a>;
  49 ┆ }
  
  deprecated: ReasonReact.arrayToElement
Please use ReasonReact.array instead
```