### PR TITLE
Refactor to Hook Api with backwards-compatible wrappers

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -4,7 +4,7 @@
   "refmt": 3,
   "bs-dependencies": ["reason-react"],
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "namespace": false,
   "sources": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/callstack/reroute#readme",
   "devDependencies": {
-    "bs-platform": "^5.0.1",
+    "bs-platform": "^5.0.4",
     "reason-react": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reason-reroute",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Tiny wrapper around ReasonReact.Router ",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/callstack/reroute#readme",
   "devDependencies": {
-    "bs-platform": "^4.0.3",
-    "reason-react": "^0.5.3"
+    "bs-platform": "^5.0.1",
+    "reason-react": "^0.7.0"
   }
 }

--- a/src/ReRoute.re
+++ b/src/ReRoute.re
@@ -6,7 +6,7 @@ module type RouterConfig = {
 
 module CreateRouter = (Config: RouterConfig) => {
   let useRouter = () => {
-    let (currentRoute, setCurrentRoute) =
+    let (currentRoute: Config.route, setCurrentRoute) =
       React.useState(() =>
         ReasonReact.Router.dangerouslyGetInitialUrl() |> Config.routeFromUrl
       );
@@ -24,10 +24,6 @@ module CreateRouter = (Config: RouterConfig) => {
   };
 
   module Container = {
-    type action =
-      | ChangeRoute(Config.route);
-    type state = Config.route;
-
     [@react.component]
     let make = (~children) => {
       let currentRoute = useRouter();

--- a/src/ReRoute.re
+++ b/src/ReRoute.re
@@ -1,6 +1,6 @@
 module type RouterConfig = {
   type route;
-  let routeFromUrl: ReasonReact.Router.url => route;
+  let routeFromUrl: ReasonReactRouter.url => route;
   let routeToUrl: route => string;
 };
 
@@ -13,17 +13,17 @@ module CreateRouter = (Config: RouterConfig) => {
     let make = children => {
       ...component,
       initialState: () =>
-        ReasonReact.Router.dangerouslyGetInitialUrl() |> Config.routeFromUrl,
+        ReasonReactRouter.dangerouslyGetInitialUrl() |> Config.routeFromUrl,
       reducer: (action, _state) =>
         switch (action) {
         | ChangeRoute(route) => ReasonReact.Update(route)
         },
       didMount: self => {
         let watcherID =
-          ReasonReact.Router.watchUrl(url =>
+          ReasonReactRouter.watchUrl(url =>
             self.send(ChangeRoute(url |> Config.routeFromUrl))
           );
-        self.onUnmount(() => ReasonReact.Router.unwatchUrl(watcherID));
+        self.onUnmount(() => ReasonReactRouter.unwatchUrl(watcherID));
       },
       render: self => children(~currentRoute=self.state),
     };
@@ -39,7 +39,7 @@ module CreateRouter = (Config: RouterConfig) => {
           onClick=(
             event => {
               event->ReactEvent.Synthetic.preventDefault;
-              ReasonReact.Router.push(href);
+              ReasonReactRouter.push(href);
             }
           )>
           (ReasonReact.array(children))

--- a/src/ReRoute.re
+++ b/src/ReRoute.re
@@ -5,28 +5,28 @@ module type RouterConfig = {
 };
 
 module CreateRouter = (Config: RouterConfig) => {
+  let useRouter = () => {
+    let (currentRoute, setCurrentRoute) =
+      React.useState(() =>
+        ReasonReact.Router.dangerouslyGetInitialUrl() |> Config.routeFromUrl
+      );
+    React.useEffect1(
+      () => {
+        let watcherID =
+          ReasonReact.Router.watchUrl(url =>
+            setCurrentRoute(_old => url |> Config.routeFromUrl)
+          );
+        Some(() => ReasonReact.Router.unwatchUrl(watcherID));
+      },
+      [||],
+    );
+    currentRoute;
+  };
+
   module Container = {
     type action =
       | ChangeRoute(Config.route);
     type state = Config.route;
-
-    let useRouter = () => {
-      let (currentRoute, setCurrentRoute) =
-        React.useState(() =>
-          ReasonReact.Router.dangerouslyGetInitialUrl() |> Config.routeFromUrl
-        );
-      React.useEffect1(
-        () => {
-          let watcherID =
-            ReasonReact.Router.watchUrl(url =>
-              setCurrentRoute(_old => url |> Config.routeFromUrl)
-            );
-          Some(() => ReasonReact.Router.unwatchUrl(watcherID));
-        },
-        [||],
-      );
-      currentRoute;
-    };
 
     [@react.component]
     let make = (~children) => {

--- a/src/ReRoute.re
+++ b/src/ReRoute.re
@@ -9,42 +9,65 @@ module CreateRouter = (Config: RouterConfig) => {
     type action =
       | ChangeRoute(Config.route);
     type state = Config.route;
-    let component = ReasonReact.reducerComponent("CallstackRerouteRouter");
-    let make = children => {
-      ...component,
-      initialState: () =>
-        ReasonReactRouter.dangerouslyGetInitialUrl() |> Config.routeFromUrl,
-      reducer: (action, _state) =>
-        switch (action) {
-        | ChangeRoute(route) => ReasonReact.Update(route)
+
+    [@react.component]
+    let make = (~children) => {
+      let (state, send) =
+        React.useReducer(
+          (_oldState, ChangeRoute(newRoute)) => newRoute,
+          ReasonReact.Router.dangerouslyGetInitialUrl() |> Config.routeFromUrl,
+        );
+      React.useEffect1(
+        () => {
+          let watcherID =
+            ReasonReact.Router.watchUrl(url =>
+              send(ChangeRoute(url |> Config.routeFromUrl))
+            );
+          Some(() => ReasonReact.Router.unwatchUrl(watcherID));
         },
-      didMount: self => {
-        let watcherID =
-          ReasonReactRouter.watchUrl(url =>
-            self.send(ChangeRoute(url |> Config.routeFromUrl))
-          );
-        self.onUnmount(() => ReasonReactRouter.unwatchUrl(watcherID));
-      },
-      render: self => children(~currentRoute=self.state),
+        [||],
+      );
+      children(~currentRoute=state);
+    };
+
+    module Jsx2 = {
+      let component = ReasonReact.statelessComponent("RouterContainer");
+
+      let make = children =>
+        ReasonReactCompat.wrapReactForReasonReact(
+          make,
+          makeProps(~children, ()),
+          children,
+        );
     };
   };
   module Link = {
-    let component = ReasonReact.statelessComponent("CallstackRerouteLink");
-    let make = (~route, children) => {
-      ...component,
-      render: _self => {
-        let href = Config.routeToUrl(route);
-        <a
-          href
-          onClick=(
-            event => {
-              event->ReactEvent.Synthetic.preventDefault;
-              ReasonReactRouter.push(href);
-            }
-          )>
-          (ReasonReact.array(children))
-        </a>;
-      },
+    [@react.component]
+    let make = (~route, ~className=?, ~children) => {
+      let href = Config.routeToUrl(route);
+      <a
+        href
+        ?className
+        onClick={
+          event => {
+            event->ReactEvent.Synthetic.preventDefault;
+            ReasonReact.Router.push(href);
+          }
+        }>
+        children
+      </a>;
+    };
+
+    module Jsx2 = {
+      let component = ReasonReact.statelessComponent("Link");
+
+      let make =
+          (~route, ~className=?, children: array(ReasonReact.reactElement)) =>
+        ReasonReactCompat.wrapReactForReasonReact(
+          make,
+          makeProps(~route, ~className?, ~children=React.array(children), ()),
+          React.array(children),
+        );
     };
   };
 };


### PR DESCRIPTION
It seems the Router moved to a new namespace in the ReasonReact update. I hope you will accept this small fix to adapt.